### PR TITLE
removed uses of monkey patched Array#sum

### DIFF
--- a/examples/boolean_example.rb
+++ b/examples/boolean_example.rb
@@ -10,8 +10,8 @@ Rulp::log_level = Logger::INFO
 ##
 
 items       = 50.times.map(&Shop_Item_b)
-items_count = items.sum
-items_costs = items.map{|item| item * Random.rand(1.0...5.0)}.sum
+items_count = items.inject(:+)
+items_costs = items.map{|item| item * Random.rand(1.0...5.0)}.inject(:+)
 
 Rulp::Min( items_costs ) [
   items_count  >= 10,

--- a/lib/extensions/array_extensions.rb
+++ b/lib/extensions/array_extensions.rb
@@ -1,5 +1,0 @@
-class Array
-  def sum
-    self.inject(:+)
-  end
-end

--- a/lib/extensions/extensions.rb
+++ b/lib/extensions/extensions.rb
@@ -1,4 +1,3 @@
-require_relative './array_extensions'
 require_relative './kernel_extensions'
 require_relative './object_extensions'
 require_relative './file_extensions'

--- a/test/test_boolean.rb
+++ b/test/test_boolean.rb
@@ -8,8 +8,8 @@ require_relative 'test_helper'
 class BooleanTest < Minitest::Test
   def setup
     @items       = 30.times.map(&Shop_Item_b)
-    items_count = @items.sum
-    @items_costs = @items.map{|item| item * Random.rand(1.0...5.0)}.sum
+    items_count = @items.inject(:+)
+    @items_costs = @items.map{|item| item * Random.rand(1.0...5.0)}.inject(:+)
 
     @problem =
     Rulp::Min( @items_costs ) [

--- a/test/test_infeasible.rb
+++ b/test/test_infeasible.rb
@@ -8,8 +8,8 @@ require_relative 'test_helper'
 class InfeasibleTest < Minitest::Test
   def setup
     @items       = 30.times.map(&Shop_Item_b)
-    items_count = @items.sum
-    @items_costs = @items.map{|item| item * Random.rand(1.0...5.0)}.sum
+    items_count = @items.inject(:+)
+    @items_costs = @items.map{|item| item * Random.rand(1.0...5.0)}.inject(:+)
 
     @problem =
     Rulp::Min( @items_costs ) [


### PR DESCRIPTION
Removed uses of monkey patched Array#sum in favor of explicit `.inject…(:+)` due to conflicts with the latest ruby and rails implementations of sum. Ruby's Array#Sum is an optimized algorithm that does not simply loop over + methods as inject will.

This addresses the issues outlined in https://github.com/wouterken/rulp/issues/9