### PR TITLE
added missing require for date preventing bundle on ruby 2.7+

### DIFF
--- a/rulp.gemspec
+++ b/rulp.gemspec
@@ -1,6 +1,7 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rulp/version'
+require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'rulp'


### PR DESCRIPTION
The `Date` library is no longer required by default in new versions of ruby ( since 1.9 I think? ).

When using newer version of ruby 2.7 and bundler 2.3.3 this missing require causes bundle to fail!

```bash
$ bundle    
Invalid gemspec in [/home/######/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/bundler/gems/rulp-b3712cc0208c/rulp.gemspec]: uninitialized constant Gem::Specification::Date    
...

Unfortunately, an unexpected error occurred, and Bundler cannot continue.
```

More simply:

```
$ ruby --version 
ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [x86_64-linux]

$ ruby -e 'puts Date.today'
Traceback (most recent call last):
-e:1:in `<main>': uninitialized constant Date (NameError)
Did you mean?  Data

$ ruby -rdate -e 'puts Date.today'
2021-12-26
```

Adding this require should lifeboat this code at least until ruby 3.  Most likely I will be using this library for the foreseeable future, so when I upgrade to ruby 3 I will make sure to share any pull requests or findings along the way!